### PR TITLE
update onnx version in benchmarkai

### DIFF
--- a/onnx_benchmark/setup.sh
+++ b/onnx_benchmark/setup.sh
@@ -19,7 +19,7 @@ install_onnx()
     echo "Installing protobuf ......."
     sudo apt-get -y install protobuf-compiler libprotoc-dev
     echo "Installing ONNX version 1.1.1 ........"
-    sudo pip  install protobuf==3.5.2 onnx==1.1.1
+    sudo pip  install protobuf==3.5.2 onnx==1.3.0
 }
 
 


### PR DESCRIPTION
Benchmarkai script was using old onnx version(1.1.1). MXNet now supports ONNX(1.3.0). So upgrading the version.
@leleamol 